### PR TITLE
Fix Back2BackCompatibilityTest, because Bintray platform was shut down

### DIFF
--- a/src/test/java/integration/Back2BackCompatibilityTest.java
+++ b/src/test/java/integration/Back2BackCompatibilityTest.java
@@ -75,18 +75,6 @@ public class Back2BackCompatibilityTest {
     }
 
     @Test
-    public void checkGifLwMojo() throws Exception {
-        final File basedir = resources.getBasedir("truncate-project");
-        final MavenExecution mavenExecution = maven
-                .forProject(basedir)
-                .withCliOption("-Pgiflw");
-        final MavenExecutionResult result = mavenExecution.execute("clean", "com.github.jmdesprez:plantuml-maven-plugin:generate");
-        result.assertErrorFreeLog();
-        assertFilesPresent(basedir, "target/plantuml/AblaufManuelleGenerierung.png");
-        assertFilesPresent(basedir, "target/plantuml/QueueStatechart.png");
-    }
-
-    @Test
     public void checkJeluardMojo() throws Exception {
         final File basedir = resources.getBasedir("truncate-project");
         final MavenExecution mavenExecution = maven

--- a/src/test/resources/integration/truncate-project/pom.xml
+++ b/src/test/resources/integration/truncate-project/pom.xml
@@ -68,8 +68,8 @@
             <id>bvfalcon</id>
             <pluginRepositories>
                 <pluginRepository>
-                    <id>bintray-bvfalcon</id>
-                    <url>https://dl.bintray.com/jmdesprez/maven</url>
+                    <id>mulesoft</id>
+                    <url>https://repository.mulesoft.org/nexus/content/repositories/public/</url>
                 </pluginRepository>
             </pluginRepositories>
             <build>
@@ -104,8 +104,8 @@
             <id>giflw</id>
             <pluginRepositories>
                 <pluginRepository>
-                    <id>bintray-giflw</id>
-                    <url>https://dl.bintray.com/jmdesprez/maven</url>
+                    <id>mulesoft</id>
+                    <url>https://repository.mulesoft.org/nexus/content/repositories/public/</url>
                 </pluginRepository>
             </pluginRepositories>
             <build>

--- a/src/test/resources/integration/truncate-project/pom.xml
+++ b/src/test/resources/integration/truncate-project/pom.xml
@@ -101,42 +101,6 @@
             </build>
         </profile>
         <profile>
-            <id>giflw</id>
-            <pluginRepositories>
-                <pluginRepository>
-                    <id>mulesoft</id>
-                    <url>https://repository.mulesoft.org/nexus/content/repositories/public/</url>
-                </pluginRepository>
-            </pluginRepositories>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>com.github.jmdesprez</groupId>
-                        <artifactId>plantuml-maven-plugin</artifactId>
-                        <version>1.3</version>
-                        <configuration>
-                            <outputDirectory>${basedir}/target/plantuml</outputDirectory>
-                            <truncatePattern>src/main/*</truncatePattern>
-                            <sourceFiles>
-                                <directory>${basedir}</directory>
-                                <includes>
-                                    <include>src/main/plantuml/**/*.txt</include>
-                                </includes>
-                            </sourceFiles>
-                        </configuration>
-                        <dependencies>
-                            <dependency>
-                                <groupId>net.sourceforge.plantuml</groupId>
-                                <artifactId>plantuml</artifactId>
-                                <version>7999</version>
-                                <scope>runtime</scope>
-                            </dependency>
-                        </dependencies>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-        <profile>
             <id>jeluard</id>
             <pluginRepositories>
                 <pluginRepository>


### PR DESCRIPTION
Bintray is down. By searching mvnrepository.com, I found the Mulesoft repository, which is still hosting plugin variant `com.github.jmdesprez:plantuml-maven-plugin:1.3`, which is used in
  - `Back2BackCompatibilityTest.checkBvFalconMojo`
  - `Back2BackCompatibilityTest.checkGifLwMojo`

**Update:** The second commit removes a duplicate plugin profile in the test POM. Maybe initially, this was meant to become something distinct after initial copy & paste, but other than the profile name, everything else was exactly the same.