### PR TITLE
Refactor build process and Back2BackCompatibilityTest

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -15,7 +15,4 @@ jobs:
         java-version: '13'
     - name: Build with Maven
       run: |
-        ./mvnw    -Pjava-8 clean site install
         ./mvnw -U -PpruefeVersionen,release clean site install
-        ./mvnw    -Pjava8ci clean site install
-

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -9,6 +9,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
+    - name: Setup Graphviz
+      uses: ts-graphviz/setup-graphviz@v1
     - name: Set up JDK 13
       uses: actions/setup-java@v1
       with:

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,6 +1,6 @@
 name: Github CI Build
 
-on: [push]
+on: [push, workflow_dispatch]
 
 jobs:
   build:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,5 +23,4 @@ jobs:
       run: |
         mkdir -p ~/.m2
         echo "<settings><servers><server><id>github</id><username>OWNER</username><password>${GITHUB_TOKEN}</password></server></servers></settings>" > ~/.m2/settings.xml
-        ./mvnw -U -Pjava8ci clean install deploy
         ./mvnw -U -Prelease site install deploy

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
+    - name: Setup Graphviz
+      uses: ts-graphviz/setup-graphviz@v1
     - name: Set up JDK 13
       uses: actions/setup-java@v1
       with:

--- a/pom.xml
+++ b/pom.xml
@@ -44,17 +44,13 @@
         </repository>
     </distributionManagement>
 
-
-    <prerequisites>
-        <maven>${mavenVersion}</maven>
-    </prerequisites>
-
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <mavenVersion>3.6.3</mavenVersion>
-        <java.build.version>13</java.build.version>
-        <java.target.version>11</java.target.version>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <mavenAPIVersion>3.8.1</mavenAPIVersion>
+        <mavenBuildVersion>3.6.3</mavenBuildVersion>
     </properties>
 
     <dependencies>
@@ -67,12 +63,12 @@
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-plugin-api</artifactId>
-            <version>${mavenVersion}</version>
+            <version>${mavenAPIVersion}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-model</artifactId>
-            <version>${mavenVersion}</version>
+            <version>${mavenAPIVersion}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven.plugin-tools</groupId>
@@ -89,13 +85,13 @@
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-compat</artifactId>
-            <version>${mavenVersion}</version>
+            <version>${mavenAPIVersion}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-core</artifactId>
-            <version>${mavenVersion}</version>
+            <version>${mavenAPIVersion}</version>
             <scope>test</scope>
         </dependency>
 
@@ -116,7 +112,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.13.1</version>
+            <version>4.13.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -130,6 +126,12 @@
     <build>
         <plugins>
             <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <argLine>${jvm.arg.addOpens}</argLine>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
                 <executions>
@@ -141,10 +143,10 @@
                         <configuration>
                             <rules>
                                 <requireMavenVersion>
-                                    <version>${mavenVersion}</version>
+                                    <version>${mavenBuildVersion}</version>
                                 </requireMavenVersion>
                                 <requireJavaVersion>
-                                    <version>${java.build.version}</version>
+                                    <version>${maven.compiler.source}</version>
                                 </requireJavaVersion>
                             </rules>
                         </configuration>
@@ -155,12 +157,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <encoding>UTF-8</encoding>
-                    <release>${java.target.version}</release>
                     <compilerArgs>
                         <arg>-Xlint:all</arg>
-                        <arg>--add-opens=java.base/java.lang=ALL-UNNAMED</arg>
-                        <arg>--add-opens=java.base/java.net=ALL-UNNAMED</arg>
                     </compilerArgs>
                     <fork>true</fork>
                 </configuration>
@@ -311,6 +309,25 @@
 
     <profiles>
         <profile>
+            <id>jdk-8-to-15</id>
+            <activation>
+                <jdk>[1.8,16)</jdk>
+            </activation>
+            <properties>
+                <jvm.arg.addOpens/>
+            </properties>
+        </profile>
+        <profile>
+            <id>jdk-16-to-xx</id>
+            <activation>
+                <jdk>[16,)</jdk>
+            </activation>
+            <properties>
+                <!-- Legacy 'jmdesprez' plugin used in compatibility test needs access to internal JDK API -->
+                <jvm.arg.addOpens>--add-opens java.desktop/com.sun.imageio.plugins.png=ALL-UNNAMED</jvm.arg.addOpens>
+            </properties>
+        </profile>
+        <profile>
             <id>pruefeVersionen</id>
             <build>
                 <plugins>
@@ -337,73 +354,6 @@
                 </plugins>
             </build>
 
-        </profile>
-        <profile>
-            <id>java8ci</id>
-            <properties>
-                <maven.compiler.target>1.8</maven.compiler.target>
-                <java.build.version>1.8</java.build.version>
-                <java.target.version>1.8</java.target.version>
-                <maven.compiler.source>1.8</maven.compiler.source>
-            </properties>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-compiler-plugin</artifactId>
-                        <configuration combine.self="override">
-                            <encoding>UTF-8</encoding>
-                            <compilerArgs>
-                                <arg>-Xlint:all</arg>
-                            </compilerArgs>
-                            <fork>true</fork>
-                        </configuration>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-jar-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <phase>package</phase>
-                                <goals>
-                                    <goal>jar</goal>
-                                </goals>
-                                <configuration>
-                                    <classifier>java8</classifier>
-                                </configuration>
-                            </execution>
-                        </executions>
-
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-        <profile>
-            <id>java-8</id>
-            <activation>
-                <jdk>1.8</jdk>
-            </activation>
-            <properties>
-                <maven.compiler.target>1.8</maven.compiler.target>
-                <java.build.version>1.8</java.build.version>
-                <java.target.version>1.8</java.target.version>
-                <maven.compiler.source>1.8</maven.compiler.source>
-            </properties>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-compiler-plugin</artifactId>
-                        <configuration combine.self="override">
-                            <encoding>UTF-8</encoding>
-                            <compilerArgs>
-                                <arg>-Xlint:all</arg>
-                            </compilerArgs>
-                            <fork>true</fork>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
         </profile>
         <profile>
             <id>release</id>

--- a/src/test/java/integration/Back2BackCompatibilityTest.java
+++ b/src/test/java/integration/Back2BackCompatibilityTest.java
@@ -36,7 +36,11 @@ import static io.takari.maven.testing.TestResources.assertFilesPresent;
 
 // http://takari.io/book/70-testing.html
 @RunWith(MavenJUnitTestRunner.class)
-@MavenVersions({ "3.1.1", "3.2.5", "3.3.9", "3.5.4", "3.6.3", "3.8.1" })
+// Maven 3.1.1 works, but is so old it wants to download from Maven Central via HTTP instead of HTTPS. But HTTP download
+// has been deactivated by Sonatype a while ago. If someone works with a proxy or behind a Nexus + firewall in an
+// enterprise setting on an old Maven version, this can still work. Maven 3.1.1 can use this plugin, it is simply a
+// download problem.
+@MavenVersions({ /*"3.1.1",*/ "3.2.5", "3.3.9", "3.5.4", "3.6.3", "3.8.1" })
 public class Back2BackCompatibilityTest {
 
     @Rule

--- a/src/test/java/integration/Back2BackCompatibilityTest.java
+++ b/src/test/java/integration/Back2BackCompatibilityTest.java
@@ -54,16 +54,20 @@ public class Back2BackCompatibilityTest {
 
     @Test
     public void checkHuluvu424242Mojo() throws Exception {
+        // This plugin works with both the Smetana engine and with a local GraphViz installation.
         checkMojo("funthomas424242", true);
     }
 
     @Test
     public void checkJmdesprezMojo() throws Exception {
+        // ATTENTION: This legacy plugin needs an old API and a local GraphViz installation.
+        // If it was not for this test, no local GraphViz installation would be necessary for the whole test suite.
         checkMojo("jmdesprez", true);
     }
 
     @Test
     public void checkJeluardMojo() throws Exception {
+        // This plugin works with both the Smetana engine and with a local GraphViz installation.
         checkMojo("jeluard", false);
     }
 

--- a/src/test/java/integration/Back2BackCompatibilityTest.java
+++ b/src/test/java/integration/Back2BackCompatibilityTest.java
@@ -74,10 +74,10 @@ public class Back2BackCompatibilityTest {
         MavenExecutionResult result = mavenExecution.execute("clean", pluginMavenCoordinates);
         result.assertErrorFreeLog();
 
-        // 'jdot' binary not found 
+        // 'jdot' binary not found
         result.assertNoLogText("java.io.IOException");
 
-        // Problems interacting with Semtana API
+        // Problems interacting with Smetana API
         result.assertNoLogText("java.lang.InvocationTargetException");
         result.assertNoLogText("java.lang.UnsupportedOperationException");
         result.assertNoLogText("java.lang.ClassFormatError");
@@ -87,5 +87,3 @@ public class Back2BackCompatibilityTest {
         assertFilesPresent(baseDir, subDir + "QueueStatechart.png");
     }
 }
-
-

--- a/src/test/resources/integration/truncate-project/pom.xml
+++ b/src/test/resources/integration/truncate-project/pom.xml
@@ -65,7 +65,7 @@
             </build>
         </profile>
         <profile>
-            <id>bvfalcon</id>
+            <id>jmdesprez</id>
             <pluginRepositories>
                 <pluginRepository>
                     <id>mulesoft</id>

--- a/src/test/resources/integration/truncate-project/pom.xml
+++ b/src/test/resources/integration/truncate-project/pom.xml
@@ -92,6 +92,10 @@
                             <dependency>
                                 <groupId>net.sourceforge.plantuml</groupId>
                                 <artifactId>plantuml</artifactId>
+                                <!--
+                                  ATTENTION: Do not upgrade to a recent version.
+                                  This legacy plugin needs an old API and a local GraphViz installation.
+                                -->
                                 <version>7999</version>
                                 <scope>runtime</scope>
                             </dependency>

--- a/src/test/resources/integration/truncate-project/pom.xml
+++ b/src/test/resources/integration/truncate-project/pom.xml
@@ -7,9 +7,9 @@
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
   You may obtain a copy of the License at
-  
+
        http://www.apache.org/licenses/LICENSE-2.0
-  
+
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -67,10 +67,10 @@
         <profile>
             <id>jmdesprez</id>
             <pluginRepositories>
-                <pluginRepository>
-                    <id>mulesoft</id>
-                    <url>https://repository.mulesoft.org/nexus/content/repositories/public/</url>
-                </pluginRepository>
+              <pluginRepository>
+                <id>aspectj-dev</id>
+                <url>https://aspectj.dev/maven</url>
+              </pluginRepository>
             </pluginRepositories>
             <build>
                 <plugins>

--- a/src/test/resources/integration/truncate-project/src/main/plantuml/AblaufManuelleGenerierung.txt
+++ b/src/test/resources/integration/truncate-project/src/main/plantuml/AblaufManuelleGenerierung.txt
@@ -1,6 +1,4 @@
 @startuml
-!pragma graphviz_dot jdot
-
 
 interface AbstractQueueFluentBuilder <<generierte Spec des Fluent API>>
 note right: generiert

--- a/src/test/resources/integration/truncate-project/src/main/plantuml/QueueStatechart.txt
+++ b/src/test/resources/integration/truncate-project/src/main/plantuml/QueueStatechart.txt
@@ -1,5 +1,4 @@
 @startuml
-!pragma graphviz_dot jdot
 
 state "Empty" as Empty
 state "Not Empty" as NotEmpty


### PR DESCRIPTION
This commit does a bit too much, sorry:
  - Remove restriction for users: plugin is usable with Maven 3.1.1+ now.
  - Refactor `Back2BackCompatibilityTest` by reducing duplication and by testing all plugins with Maven versions 3.1.1, 3.2.5, 3.3.9, 3.5.4, 3.6.3., 3.8.1. This makes the test slower, but ensures that the plugin stays compatible with older Maven versions.
  - Always build with target Java 8, because building with target 11 has no advantage whatsoever. Now the plugin can always be used with JDK 8+. Tested locally on JDKs 8-16.
  - In order to enable JDK 16 builds, add Surefire JVM parameter `--add-opens java.desktop/com.sun.imageio.plugins.png=ALL-UNNAMED`, because the legacy `jmdesprez` plugin needs it during the E2E compatibility test.
  - Remove redundant build profiles in POM and in GitHub workflows.
  - Remove `!pragma graphviz_dot jdot` from test diagrams, because they cause failures in `Back2BackCompatibilityTest`. Even though the test passed, it never actually worked. There were huge stack traces on the console. The test checks for some typical errors in the console log now in order to be able to fail the test in those cases. This addresses issue #30.
  - Upgrade to Maven plugin API 3.8.1. This does not limit the plugin's ability to run e.g. on Maven 3.1.1 and also does not mean that we need to use Maven 3.8.1 in order to build it. Maven 3.6.3 is still enough, and even that would not be necessary without the Takari test environment.

**Please note:** This PR also includes the changes for #29, otherwise I would not have been able to test. So actually, when merging this one, it superseeds #29, which can be closed too, after this one was has been merged.